### PR TITLE
Fix wrong timezone when UpdateFromAnilist

### DIFF
--- a/awc/templates/partials/search-anime-modal.html
+++ b/awc/templates/partials/search-anime-modal.html
@@ -44,10 +44,9 @@
 		  if (val.mediaListEntry != null) {
 		      card.attr('data-completed', val.mediaListEntry.status);
 
-		      var startDate = new Date(val.mediaListEntry.startedAt.year, val.mediaListEntry.startedAt.month - 1, val.mediaListEntry.startedAt.day);
-		      var finishDate = new Date(val.mediaListEntry.completedAt.year, val.mediaListEntry.completedAt.month - 1, val.mediaListEntry.completedAt.day);
+		      var startDate = new Date(Date.UTC(val.mediaListEntry.startedAt.year, val.mediaListEntry.startedAt.month - 1, val.mediaListEntry.startedAt.day));
+		      var finishDate = new Date(Date.UTC(val.mediaListEntry.completedAt.year, val.mediaListEntry.completedAt.month - 1, val.mediaListEntry.completedAt.day));
 
-		      
 		      card.attr('data-start', startDate.toISOString().split("T")[0]);
 		      card.attr('data-finish', finishDate.toISOString().split("T")[0]);
 		  }


### PR DESCRIPTION
This fixes a bug where the date is off by one day when clicking the UpdateFromAnilist-Button. This is caused by timezone differences.
You can refer to: [https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off](https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off)